### PR TITLE
Fixes #11

### DIFF
--- a/cmake-scripts/TracerConfig.cmake
+++ b/cmake-scripts/TracerConfig.cmake
@@ -1,5 +1,5 @@
 # In two-number form only. LLVM-Tracer will determine the patch version for you.
-if(NOT DEFINED LLVM_RECOMMEND_VERSION)
+if(NOT DEFINED ENV{LLVM_RECOMMEND_VERSION})
   SET(LLVM_RECOMMEND_VERSION 3.4)
 endif()
 


### PR DESCRIPTION
In the `TracerConfig.cmake` LLVM version is checked as `if(NOT DEFINED LLVM_RECOMMEND_VERSION)`. I believe the correct line should say `if(NOT DEFINED ENV{LLVM_RECOMMEND_VERSION})`.
[cmake pipermail](https://cmake.org/pipermail/cmake/2011-October/046706.html)

That way one can have `export LLVM_RECOMMEND_VERSION="3.x"` in the environment setup
