### PR TITLE
Fix compatibility with LLVM 3.5

### DIFF
--- a/full-trace/full_trace.cpp
+++ b/full-trace/full_trace.cpp
@@ -7,7 +7,6 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Type.h"
-#include "llvm/DebugInfo.h"
 #include "llvm/Support/CommandLine.h"
 #include <cstring>
 #include <cstdlib>
@@ -19,6 +18,12 @@
 #include <sys/stat.h>
 #include "SlotTracker.h"
 #include "full_trace.h"
+
+#if (LLVM_VERSION == 34)
+  #include "llvm/DebugInfo.h"
+#elif (LLVM_VERSION == 35)
+  #include "llvm/IR/DebugInfo.h"
+#endif
 
 #define RESULT_LINE 19134
 #define FORWARD_LINE 24601


### PR DESCRIPTION
Recent updates broke compatibility with LLVM 3.5, reported in #20
Made 3 fixes for the issue:
1. Add cl::OptionCategory in GetLabelStmtsCat because CommonOptionsParser() requires it in LLVM 3.5
2. Use unique_ptr to keep pointers from actionfactory(), which returns a unique_ptr in LLVM 3.5, instead of a raw pointer.
3. Include "llvm/DebugInfo.h" or "llvm/IR/DebugInfo.h" according to the LLVM version.